### PR TITLE
Spacemacs OS

### DIFF
--- a/layers/+window-management/exwm/config.el
+++ b/layers/+window-management/exwm/config.el
@@ -1,11 +1,14 @@
-(defvar exwm--terminal-command "xterm"
+(defvar exwm/terminal-command "xterm"
   "Terminal command to run.")
 
-(defvar exwm--locking-command "lock"
+(defvar exwm/locking-command "slock"
   "Command to run when locking session")
 
-(defvar exwm-app-launcher--prompt "$ "
-  "Prompt for the EXWM application launcher")
-
-(defvar exwm--hide-tiling-modeline nil
+(defvar exwm/hide-tiling-modeline nil
   "Whether to hide modeline.")
+
+(defvar exwm/leader-key nil
+  "Key to use for EXWM global commands")
+
+(defvar exwm/exwm-workspace-switch-wrap t
+  "Whether `exwm/exwm-workspace-next' and `exwm/exwm-workspace-prev' should wrap.")

--- a/layers/+window-management/exwm/config.el
+++ b/layers/+window-management/exwm/config.el
@@ -12,3 +12,9 @@
 
 (defvar exwm/exwm-workspace-switch-wrap t
   "Whether `exwm/exwm-workspace-next' and `exwm/exwm-workspace-prev' should wrap.")
+
+(defvar exwm/workspace-number nil
+  "Number of workspaces. Defaults to the number of connected displays if `nil'.")
+
+(defvar exwm/xrandr-command nil
+  "`xrandr' command to set up displays prior to EXWM init.")

--- a/layers/+window-management/exwm/config.el
+++ b/layers/+window-management/exwm/config.el
@@ -1,20 +1,20 @@
-(defvar exwm/terminal-command "xterm"
+(defvar exwm-terminal-command "xterm"
   "Terminal command to run.")
 
-(defvar exwm/locking-command "slock"
+(defvar exwm-locking-command "slock"
   "Command to run when locking session")
 
-(defvar exwm/hide-tiling-modeline nil
+(defvar exwm-hide-tiling-modeline nil
   "Whether to hide modeline.")
 
-(defvar exwm/leader-key nil
+(defvar exwm-leader-key nil
   "Key to use for EXWM global commands")
 
-(defvar exwm/exwm-workspace-switch-wrap t
+(defvar exwm-workspace-switch-wrap t
   "Whether `exwm/exwm-workspace-next' and `exwm/exwm-workspace-prev' should wrap.")
 
-(defvar exwm/workspace-number nil
+(defvar exwm-workspace-number nil
   "Number of workspaces. Defaults to the number of connected displays if `nil'.")
 
-(defvar exwm/xrandr-command nil
+(defvar exwm-randr-command nil
   "`xrandr' command to set up displays prior to EXWM init.")

--- a/layers/+window-management/exwm/files/exwm-start
+++ b/layers/+window-management/exwm/files/exwm-start
@@ -5,9 +5,6 @@ xhost +
 ## you might need to append the TTY you are working on
 xinit
 
-# Remap caps lock to left control. This is not strictly speaking
-# exwm related, but it's handy
-setxkbmap -option 'ctrl:no caps'
 wmname EXWM
 
 # Set fallback cursor

--- a/layers/+window-management/exwm/files/exwm-start
+++ b/layers/+window-management/exwm/files/exwm-start
@@ -13,10 +13,5 @@ wmname EXWM
 # Set fallback cursor
 xsetroot -cursor_name left_ptr
 
-# If Emacs is started in server mode, `emacsclient` is a convenient way to edit
-# files in place (used by e.g. `git commit`)
-export VISUAL=emacsclient
-export EDITOR="$VISUAL"
-
 # Finally launch emacs and enable exwm
 exec dbus-launch --exit-with-session emacs --eval "(exwm-enable)"

--- a/layers/+window-management/exwm/files/exwm-start
+++ b/layers/+window-management/exwm/files/exwm-start
@@ -5,11 +5,10 @@ xhost +
 ## you might need to append the TTY you are working on
 xinit
 
-wmname LG3D
-
 # Remap caps lock to left control. This is not strictly speaking
 # exwm related, but it's handy
 setxkbmap -option 'ctrl:no caps'
+wmname EXWM
 
 # Set fallback cursor
 xsetroot -cursor_name left_ptr

--- a/layers/+window-management/exwm/files/exwm-start
+++ b/layers/+window-management/exwm/files/exwm-start
@@ -11,4 +11,4 @@ wmname EXWM
 xsetroot -cursor_name left_ptr
 
 # Finally launch emacs and enable exwm
-exec dbus-launch --exit-with-session emacs --eval "(exwm-enable)"
+exec dbus-launch --exit-with-session emacs

--- a/layers/+window-management/exwm/funcs.el
+++ b/layers/+window-management/exwm/funcs.el
@@ -61,3 +61,7 @@ Can show completions at point for COMMAND using helm"
 (defun exwm/exwm-lock ()
   (interactive)
   (start-process "" nil exwm/locking-command))
+
+;; Other utilities
+(defun exwm//flatenum (i ls)
+  (if ls (cons i (cons (first ls) (exwm//flatenum  (1+ i) (cdr ls)))) (list)))

--- a/layers/+window-management/exwm/funcs.el
+++ b/layers/+window-management/exwm/funcs.el
@@ -17,7 +17,7 @@
          (overflow? (= exwm-workspace-current-index (1- exwm-workspace-number))))
     (cond
      (only-workspace? nil)
-     (overflow? (when exwm/exwm-workspace-switch-wrap
+     (overflow? (when exwm-workspace-switch-wrap
                   (exwm-workspace-switch 0)))
      (t (exwm-workspace-switch (1+ exwm-workspace-current-index))))))
 
@@ -28,7 +28,7 @@
          (overflow? (= exwm-workspace-current-index 0)))
     (cond
      (only-workspace? nil)
-     (overflow? (when exwm/exwm-workspace-switch-wrap
+     (overflow? (when exwm-workspace-switch-wrap
                   (exwm-workspace-switch (1- exwm-workspace-number))))
      (t (exwm-workspace-switch (1- exwm-workspace-current-index))))))
 
@@ -60,7 +60,7 @@ Can show completions at point for COMMAND using helm"
 
 (defun exwm/exwm-lock ()
   (interactive)
-  (start-process "" nil exwm/locking-command))
+  (start-process "" nil exwm-locking-command))
 
 ;; Other utilities
 (defun exwm//flatenum (i ls)

--- a/layers/+window-management/exwm/funcs.el
+++ b/layers/+window-management/exwm/funcs.el
@@ -33,15 +33,15 @@
      (t (exwm-workspace-switch (1- exwm-workspace-current-index))))))
 
 ;; Quick swtiching between workspaces
-(defvar exwm//toggle-workspace 0 "Previously selected workspace. Used with `exwm/jump-to-last-exwm'.")
+(defvar exwm--toggle-workspace 0 "Previously selected workspace. Used with `exwm/jump-to-last-exwm'.")
 
 (defun exwm/jump-to-last-exwm ()
   (interactive)
-  (exwm-workspace-switch exwm//toggle-workspace))
+  (exwm-workspace-switch exwm--toggle-workspace))
 
 (defadvice exwm-workspace-switch
     (before save-toggle-workspace activate)
-  (setq exwm//toggle-workspace exwm-workspace-current-index))
+  (setq exwm--toggle-workspace exwm-workspace-current-index))
 
 (defun exwm/exwm-app-launcher ()
   "Launches an application in your PATH.

--- a/layers/+window-management/exwm/funcs.el
+++ b/layers/+window-management/exwm/funcs.el
@@ -32,15 +32,6 @@
                   (exwm-workspace-switch (1- exwm-workspace-number))))
      (t (exwm-workspace-switch (1- exwm-workspace-current-index))))))
 
-(defun exwm/exwm-layout-toggle-fullscreen ()
-  "Togggles full screen for Emacs and X windows"
-  (interactive)
-  (if exwm--id
-      (if exwm--fullscreen
-          (exwm-reset)
-        (exwm-layout-set-fullscreen))
-    (exwm/toggle-maximize-buffer)))
-
 ;; Quick swtiching between workspaces
 (defvar exwm//toggle-workspace 0 "Previously selected workspace. Used with `exwm/jump-to-last-exwm'.")
 

--- a/layers/+window-management/exwm/funcs.el
+++ b/layers/+window-management/exwm/funcs.el
@@ -1,0 +1,63 @@
+(defun exwm/exwm-bind-command (key command &rest bindings)
+  "Bind KEYs to COMMANDs globally"
+  (while key
+    (exwm-input-set-key (kbd key)
+                        `(lambda ()
+                           (interactive)
+                           (start-process-shell-command ,command nil
+                                                        ,command)))
+    (setq key (pop bindings)
+          command
+          (pop bindings))))
+
+(defun exwm/exwm-workspace-next ()
+  "Switch to next exwm-workspace (to the right)."
+  (interactive)
+  (let* ((only-workspace? (equal exwm-workspace-number 1))
+         (overflow? (= exwm-workspace-current-index (1- exwm-workspace-number))))
+    (cond
+     (only-workspace? nil)
+     (overflow? (when exwm/exwm-workspace-switch-wrap
+                  (exwm-workspace-switch 0)))
+     (t (exwm-workspace-switch (1+ exwm-workspace-current-index))))))
+
+(defun exwm/exwm-workspace-prev ()
+  "Switch to next exwm-workspace (to the left)."
+  (interactive)
+  (let* ((only-workspace? (equal exwm-workspace-number 1))
+         (overflow? (= exwm-workspace-current-index 0)))
+    (cond
+     (only-workspace? nil)
+     (overflow? (when exwm/exwm-workspace-switch-wrap
+                  (exwm-workspace-switch (1- exwm-workspace-number))))
+     (t (exwm-workspace-switch (1- exwm-workspace-current-index))))))
+
+(defun exwm/exwm-layout-toggle-fullscreen ()
+  "Togggles full screen for Emacs and X windows"
+  (interactive)
+  (if exwm--id
+      (if exwm--fullscreen
+          (exwm-reset)
+        (exwm-layout-set-fullscreen))
+    (exwm/toggle-maximize-buffer)))
+
+;; Quick swtiching between workspaces
+(defvar exwm//toggle-workspace 0 "Previously selected workspace. Used with `exwm/jump-to-last-exwm'.")
+
+(defun exwm/jump-to-last-exwm ()
+  (interactive)
+  (exwm-workspace-switch exwm//toggle-workspace))
+
+(defadvice exwm-workspace-switch
+    (before save-toggle-workspace activate)
+  (setq exwm//toggle-workspace exwm-workspace-current-index))
+
+(defun exwm/exwm-app-launcher ()
+  "Launches an application in your PATH.
+Can show completions at point for COMMAND using helm"
+  (interactive)
+  (call-interactively 'helm-run-external-command))
+
+(defun exwm/exwm-lock ()
+  (interactive)
+  (start-process "" nil exwm/locking-command))

--- a/layers/+window-management/exwm/funcs.el
+++ b/layers/+window-management/exwm/funcs.el
@@ -56,7 +56,10 @@
   "Launches an application in your PATH.
 Can show completions at point for COMMAND using helm"
   (interactive)
-  (call-interactively 'helm-run-external-command))
+  (call-interactively
+   (if (configuration-layer/package-usedp 'helm)
+       'helm-run-external-command
+     'async-shell-command)))
 
 (defun exwm/exwm-lock ()
   (interactive)

--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -14,12 +14,20 @@
 ;; which require an initialization must be listed explicitly in the list.
 (defconst exwm-packages
     '(cl-generic
+      (evil-exwm-state :location (recipe :fetcher github
+                                         :repo "domenzain/evil-exwm-state"))
       (xelb :location (recipe :fetcher github
                               :repo "ch11ng/xelb")
             :step pre)
       (exwm :location (recipe :fetcher github
                               :repo "ch11ng/exwm")
             :step pre)))
+
+(defun exwm/init-evil-exwm-state ()
+  (use-package evil-exwm-state
+    :init
+    (spacemacs/define-evil-state-face "exwm" "firebrick1")
+    (spacemacs/define-evil-state-face "exwm-insert" "chartreuse3")))
 
 (defun exwm/init-cl-generic ()
   (use-package cl-generic
@@ -72,6 +80,8 @@
                    (string= "gimp" exwm-instance-name))
            (exwm-workspace-rename-buffer exwm-title))))
 
+    ;; Pass all keypresses to emacs in line mode.
+    (setq exwm-input-line-mode-passthrough t)
 
 
     ;; `exwm-input-set-key' allows you to set a global key binding (available in
@@ -134,6 +144,8 @@
     (delete ?\C-c exwm-input-prefix-keys)
     ;; We can use `M-m h' to access help
     (delete ?\C-h exwm-input-prefix-keys)
+    ;; set up evil escape
+    (exwm-input-set-key [escape] 'evil-escape)
 
     ;; Preserve the habit
     (exwm-input-set-key (kbd "s-:") 'helm-M-x)

--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -150,13 +150,6 @@
     ;; set up evil escape
     (exwm-input-set-key [escape] 'evil-escape)
 
-    ;; Undo window configurations
-    (exwm-input-set-key (kbd "s-u") #'winner-undo)
-    (exwm-input-set-key (kbd "S-s-U") #'winner-redo)
-    ;; Workspaces
-    (exwm-input-set-key (kbd "s-]") #'exwm/exwm-workspace-next)
-    (exwm-input-set-key (kbd "s-[") #'exwm/exwm-workspace-prev)
-
     ;; Bindings available everywhere
     (spacemacs/declare-prefix "W" "EXWM")
     (spacemacs/set-leader-keys
@@ -164,7 +157,7 @@
       "Wn" 'exwm/exwm-workspace-next
       "WA" 'exwm-workspace-add
       "Wd" 'exwm-workspace-delete
-      "WR" 'exwm-restart
+      "Wr" 'exwm-restart
       "Wl" 'exwm/exwm-lock
       "Wa" 'exwm/exwm-app-launcher)
 
@@ -172,7 +165,6 @@
     (spacemacs/declare-prefix-for-mode 'exwm-mode
       "mT" "toggle")
     (spacemacs/set-leader-keys-for-major-mode 'exwm-mode
-      "a" 'exwm/exwm-app-launcher
       "r" 'exwm-reset
       "Tf" 'exwm-layout-toggle-fullscreen
       "Tt" 'exwm-floating-toggle-floating

--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -168,8 +168,6 @@
     ;;    ([?\C-n] . down)
     ;;    ([?\M-v] . prior)
     ;;    ))
-
-    ;; Do not forget to enable EXWM. It will start by itself when things are ready.
-    ;; (exwm-enable)
+    (exwm-init)
     (server-start)
     ))

--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -56,6 +56,8 @@
   (use-package xelb))
 
 (defun exwm/init-exwm ()
+  (use-package exwm-randr)
+  (use-package exwm-systemtray)
   (use-package exwm
     :init
     ;; Disable dialog boxes since they are unusable in EXWM
@@ -197,6 +199,7 @@
     (setq exwm-randr-workspace-output-plist '(0 "VGA1"))
     (spacemacs/declare-prefix "W" "EXWM")
     (exwm-randr-enable)
+    (exwm-systemtray-enable)
     ;; The following example demonstrates how to use simulation keys to mimic the
     ;; behavior of Emacs. The argument to `exwm-input-set-simulation-keys' is a
     ;; list of cons cells (SRC . DEST), where SRC is the key sequence you press and

--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -103,19 +103,6 @@
                             (string= "gimp" exwm-instance-name))
                     (exwm-workspace-rename-buffer exwm-title)))))
 
-    (exwm/exwm-bind-command "s-'"  exwm-terminal-command)
-    (exwm/exwm-bind-command "<XF86MonBrightnessUp>"
-                                 "light -A 5")
-    (exwm/exwm-bind-command "<XF86MonBrightnessDown>"
-                                 "light -U 5")
-    (exwm/exwm-bind-command "<XF86AudioLowerVolume>"
-                                 "amixer -D pulse -- sset Master unmute 3%-")
-    (exwm/exwm-bind-command "<XF86AudioRaiseVolume>"
-                                 "amixer -D pulse -- sset Master unmute 3%+")
-    (exwm/exwm-bind-command "<XF86AudioMute>"
-                                 "amixer -D pulse -- sset Master toggle")
-    (exwm/exwm-bind-command "<XF86AudioMicMute>"
-                                 "amixer -D pulse -- sset Capture toggle")
     ;; Remove ALL bindings
     (define-key exwm-mode-map "\C-c\C-f" nil)
     (define-key exwm-mode-map "\C-c\C-h" nil)
@@ -129,6 +116,16 @@
                         ["Toggle mode-line" exwm-layout-toggle-mode-line])
     (easy-menu-add-item exwm-mode-menu '()
                         ["Move X window to" exwm-workspace-move-window])
+
+    (exwm/exwm-bind-command
+     "s-'"  exwm-terminal-command
+     "<s-return>"  exwm-terminal-command
+     "<XF86MonBrightnessUp>"   "light -A 5"
+     "<XF86MonBrightnessDown>" "light -U 5"
+     "<XF86AudioLowerVolume>" "amixer -D pulse -- sset Master unmute 3%-"
+     "<XF86AudioRaiseVolume>" "amixer -D pulse -- sset Master unmute 3%+"
+     "<XF86AudioMute>"        "amixer -D pulse -- sset Master toggle"
+     "<XF86AudioMicMute>"     "amixer -D pulse -- sset Capture toggle")
 
     ;; Pass all keypresses to emacs in line mode.
     (setq exwm-input-line-mode-passthrough t)

--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -116,6 +116,19 @@
                                  "amixer -D pulse -- sset Master toggle")
     (exwm/exwm-bind-command "<XF86AudioMicMute>"
                                  "amixer -D pulse -- sset Capture toggle")
+    ;; Remove ALL bindings
+    (define-key exwm-mode-map "\C-c\C-f" nil)
+    (define-key exwm-mode-map "\C-c\C-h" nil)
+    (define-key exwm-mode-map "\C-c\C-k" nil)
+    (define-key exwm-mode-map "\C-c\C-m" nil)
+    (define-key exwm-mode-map "\C-c\C-q" nil)
+    (define-key exwm-mode-map "\C-c\C-t\C-f" nil)
+    (define-key exwm-mode-map "\C-c\C-t\C-m" nil)
+    ;; Let easy-menu figure out the keys
+    (easy-menu-add-item exwm-mode-menu '()
+                        ["Toggle mode-line" exwm-layout-toggle-mode-line])
+    (easy-menu-add-item exwm-mode-menu '()
+                        ["Move X window to" exwm-workspace-move-window])
 
     ;; Pass all keypresses to emacs in line mode.
     (setq exwm-input-line-mode-passthrough t)

--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -99,6 +99,18 @@
                     (exwm-workspace-rename-buffer exwm-title)))))
 
     (exwm/exwm-bind-command "s-'"  exwm/terminal-command)
+    (exwm/exwm-bind-command "<XF86MonBrightnessUp>"
+                                 "light -A 5")
+    (exwm/exwm-bind-command "<XF86MonBrightnessDown>"
+                                 "light -U 5")
+    (exwm/exwm-bind-command "<XF86AudioLowerVolume>"
+                                 "amixer -D pulse -- sset Master unmute 3%-")
+    (exwm/exwm-bind-command "<XF86AudioRaiseVolume>"
+                                 "amixer -D pulse -- sset Master unmute 3%+")
+    (exwm/exwm-bind-command "<XF86AudioMute>"
+                                 "amixer -D pulse -- sset Master toggle")
+    (exwm/exwm-bind-command "<XF86AudioMicMute>"
+                                 "amixer -D pulse -- sset Capture toggle")
 
     ;; Pass all keypresses to emacs in line mode.
     (setq exwm-input-line-mode-passthrough t)

--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -147,17 +147,27 @@
     (exwm-input-set-key (kbd "s-]") #'exwm/exwm-workspace-next)
     (exwm-input-set-key (kbd "s-[") #'exwm/exwm-workspace-prev)
 
+    ;; Bindings available everywhere
     (spacemacs/declare-prefix "W" "EXWM")
     (spacemacs/set-leader-keys
       "Wp" 'exwm/exwm-workspace-prev
       "Wn" 'exwm/exwm-workspace-next
-      "Wf" 'exwm-layout-set-fullscreen
       "WA" 'exwm-workspace-add
       "Wd" 'exwm-workspace-delete
       "WR" 'exwm-restart
-      "Wr" 'exwm-reset
       "Wl" 'exwm/exwm-lock
       "Wa" 'exwm/exwm-app-launcher)
+
+    ;; Bindings for use only on EXWM buffers
+    (spacemacs/declare-prefix-for-mode 'exwm-mode
+      "mT" "toggle")
+    (spacemacs/set-leader-keys-for-major-mode 'exwm-mode
+      "a" 'exwm/exwm-app-launcher
+      "r" 'exwm-reset
+      "Tf" 'exwm-layout-toggle-fullscreen
+      "Tt" 'exwm-floating-toggle-floating
+      "Tm" 'exwm-layout-toggle-mode-line)
+
     (exwm-randr-enable)
     (exwm-systemtray-enable)
 

--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -257,4 +257,5 @@ Can show completions at point for COMMAND using helm or ido"
 
     ;; Do not forget to enable EXWM. It will start by itself when things are ready.
     ;; (exwm-enable)
+    (server-start)
     ))

--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -1,7 +1,7 @@
 ;;; packages.el --- exwm Layer packages File for Spacemacs
 ;;
 ;; Copyright (c) 2012-2014 Sylvain Benner
-;; Copyright (c) 2014-2015 Sylvain Benner & Contributors
+;; Copyright (c) 2014-2018 Sylvain Benner & Contributors
 ;;
 ;; Author: Sylvain Benner <sylvain.benner@gmail.com>
 ;; URL: https://github.com/syl20bnr/spacemacs

--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -176,19 +176,7 @@
     (if exwm-randr-command
      (start-process-shell-command
       "xrandr" nil exwm-randr-command))
-    ;; The following example demonstrates how to use simulation keys to mimic the
-    ;; behavior of Emacs. The argument to `exwm-input-set-simulation-keys' is a
-    ;; list of cons cells (SRC . DEST), where SRC is the key sequence you press and
-    ;; DEST is what EXWM actually sends to application. Note that SRC must be a key
-    ;; sequence (of type vector or string), while DEST can also be a single key.
 
-    ;; (exwm-input-set-simulation-keys
-    ;;  '(([?\C-b] . left)
-    ;;    ([?\C-f] . right)
-    ;;    ([?\C-p] . up)
-    ;;    ([?\C-n] . down)
-    ;;    ([?\M-v] . prior)
-    ;;    ))
     (exwm-init)
     (server-start)
     ))

--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -62,8 +62,15 @@
     :init
     ;; Disable dialog boxes since they are unusable in EXWM
     (setq use-dialog-box nil)
-    ;; 10 Worskpaces please
-    (setq exwm-workspace-number 10)
+    ;; Use as many workspaces as there are connected displays
+    ;; TODO: Is there a way of doing this with xelb?
+    (setq exwm-workspace-number
+          (list-length
+           (split-string
+            (shell-command-to-string
+             "xrandr | grep ' connected' | cut -d' ' -f1 "))))
+    ;; The workspaces will match the order in randr
+    (setq exwm-randr-workspace-output-plist '())
     ;; You may want Emacs to show you the time
     (display-time-mode t)
     (when exwm/hide-tiling-modeline
@@ -195,8 +202,6 @@
     (exwm-input-set-key (kbd "s-]") #'exwm/exwm-workspace-next)
     (exwm-input-set-key (kbd "s-[") #'exwm/exwm-workspace-prev)
 
-    (require 'exwm-randr)
-    (setq exwm-randr-workspace-output-plist '(0 "VGA1"))
     (spacemacs/declare-prefix "W" "EXWM")
     (exwm-randr-enable)
     (exwm-systemtray-enable)

--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -14,6 +14,7 @@
 ;; which require an initialization must be listed explicitly in the list.
 (defconst exwm-packages
     '(cl-generic
+      helm-exwm
       (evil-exwm-state :location (recipe :fetcher github
                                          :repo "domenzain/evil-exwm-state"))
       (xelb :location (recipe :fetcher github
@@ -22,6 +23,24 @@
       (exwm :location (recipe :fetcher github
                               :repo "ch11ng/exwm")
             :step pre)))
+
+(defun exwm/init-helm-exwm ()
+  ;; when helm is used activate extra EXWM features
+  (spacemacs|use-package-add-hook helm
+    :post-config
+    (use-package helm-exwm
+      :config
+      (progn
+        ;; Add EXWM buffers to a specific section in helm mini
+        (setq exwm/helm-exwm-emacs-buffers-source
+              (helm-exwm-build-emacs-buffers-source))
+        (setq exwm/helm-exwm-source (helm-exwm-build-source))
+        (setq helm-mini-default-sources `(exwm/helm-exwm-emacs-buffers-source
+                                          exwm/helm-exwm-source
+                                          helm-source-recentf
+                                          helm-source-buffer-not-found))
+        ;; Add a prefix command to choose among EXWM buffers only
+        (spacemacs/set-leader-keys "WW" 'helm-exwm)))))
 
 (defun exwm/init-evil-exwm-state ()
   (use-package evil-exwm-state
@@ -155,8 +174,6 @@
     ;; Undo window configurations
     (exwm-input-set-key (kbd "s-u") #'winner-undo)
     (exwm-input-set-key (kbd "S-s-U") #'winner-redo)
-    ;; Change buffers
-    (exwm-input-set-key (kbd "s-b") #'helm-mini)
     ;; Focusing windows
     (exwm-input-set-key (kbd "s-h") #'evil-window-left)
     (exwm-input-set-key (kbd "s-j") #'evil-window-down)
@@ -178,6 +195,7 @@
 
     (require 'exwm-randr)
     (setq exwm-randr-workspace-output-plist '(0 "VGA1"))
+    (spacemacs/declare-prefix "W" "EXWM")
     (exwm-randr-enable)
     ;; The following example demonstrates how to use simulation keys to mimic the
     ;; behavior of Emacs. The argument to `exwm-input-set-simulation-keys' is a

--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -65,13 +65,20 @@
     (setq use-dialog-box nil)
     ;; Use as many workspaces as there are connected displays
     ;; TODO: Is there a way of doing this with xelb?
+    (defvar exwm//randr-displays (split-string
+                            (shell-command-to-string
+                             "xrandr | grep ' connected' | cut -d' ' -f1 "))
+      "The list of connected RandR displays")
+    ;; Set at least as many workspaces as there are connected displays.
+    ;; At the user's option, begin with even more workspaces
     (setq exwm-workspace-number
-          (list-length
-           (split-string
-            (shell-command-to-string
-             "xrandr | grep ' connected' | cut -d' ' -f1 "))))
-    ;; The workspaces will match the order in randr
-    (setq exwm-randr-workspace-output-plist '())
+          (if exwm/workspace-number
+              (max exwm/workspace-number (list-length exwm//randr-displays))
+              (list-length exwm//randr-displays)))
+    ;; The first workspaces will match the order in RandR
+    (setq exwm-randr-workspace-output-plist
+          (exwm//flatenum 0 exwm//randr-displays))
+
     ;; You may want Emacs to show you the time
     (display-time-mode t)
     (when exwm/hide-tiling-modeline
@@ -155,6 +162,10 @@
       "Wa" 'exwm/exwm-app-launcher)
     (exwm-randr-enable)
     (exwm-systemtray-enable)
+
+    (if exwm/xrandr-command
+     (start-process-shell-command
+      "xrandr" nil exwm/xrandr-command))
     ;; The following example demonstrates how to use simulation keys to mimic the
     ;; behavior of Emacs. The argument to `exwm-input-set-simulation-keys' is a
     ;; list of cons cells (SRC . DEST), where SRC is the key sequence you press and

--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -12,7 +12,7 @@
 
 ;; List of all packages to install and/or initialize. Built-in packages
 ;; which require an initialization must be listed explicitly in the list.
-(setq exwm-packages
+(defconst exwm-packages
     '(cl-generic
       (xelb :location (recipe :fetcher github
                               :repo "ch11ng/xelb")
@@ -37,34 +37,14 @@
     (setq exwm-workspace-number 10)
     ;; You may want Emacs to show you the time
     (display-time-mode t)
-    (when exwm--hide-tiling-modeline
+    (when exwm/hide-tiling-modeline
       (add-hook 'exwm-mode-hook #'hidden-mode-line-mode))
-    ;; Trying to make shell-pop with a real terminal :P
-    ;; (defun exwm-launch-term ()
-    ;;   (start-process-shell-command exwm--terminal-command
-    ;;                                nil exwm--terminal-command))
-    ;; (defun shell-pop-exwm-term (index)
-    ;;   (interactive "P")
-    ;;   (require 'shell-pop)
-    ;;   (shell-pop--set-shell-type
-    ;;    'shell-pop-shell-type
-    ;;    '("exwm-term"
-    ;;      "Termite" #'exwm-launch-term))
-    ;;   (shell-pop index))
+
     :config
     (when dotspacemacs-use-ido
       (exwm-enable-ido-workaround))
-    (defun spacemacs/exwm-bind-command (key command &rest bindings)
-      (while key
-        (exwm-input-set-key (kbd key)
-                            `(lambda ()
-                               (interactive)
-                               (start-process-shell-command ,command nil ,command)))
-        (setq key     (pop bindings)
-              command (pop bindings))))
 
-    (spacemacs/exwm-bind-command
-     "<s-return>"  exwm--terminal-command)
+    (exwm/exwm-bind-command "s-'"  exwm/terminal-command)
 
     ;; All buffers created in EXWM mode are named "*EXWM*". You may want to change
     ;; it in `exwm-update-class-hook' and `exwm-update-title-hook', which are run
@@ -92,63 +72,15 @@
                    (string= "gimp" exwm-instance-name))
            (exwm-workspace-rename-buffer exwm-title))))
 
-    (defvar exwm-workspace-switch-wrap t
-      "Whether `spacemacs/exwm-workspace-next' and `spacemacs/exwm-workspace-prev' should wrap.")
 
-    (defun spacemacs/exwm-workspace-next ()
-      "Switch to next exwm-workspaceective (to the right)."
-      (interactive)
-      (let* ((only-workspace? (equal exwm-workspace-number 1))
-             (overflow? (= exwm-workspace-current-index
-                           (1- exwm-workspace-number))))
-        (cond
-         (only-workspace? nil)
-         (overflow?
-          (when exwm-workspace-switch-wrap
-              (exwm-workspace-switch 0)))
-         (t (exwm-workspace-switch  (1+ exwm-workspace-current-index))))))
-    (defun spacemacs/exwm-workspace-prev ()
-      "Switch to next exwm-workspaceective (to the right)."
-      (interactive)
-      (let* ((only-workspace? (equal exwm-workspace-number 1))
-             (overflow? (= exwm-workspace-current-index 0)))
-        (cond
-         (only-workspace? nil)
-         (overflow?
-          (when exwm-workspace-switch-wrap
-            (exwm-workspace-switch (1- exwm-workspace-number))))
-         (t (exwm-workspace-switch  (1- exwm-workspace-current-index))))))
-    (defun spacemacs/exwm-layout-toggle-fullscreen ()
-      "Togggles full screen for Emacs and X windows"
-      (interactive)
-      (if exwm--id
-          (if exwm--fullscreen
-              (exwm-reset)
-            (exwm-layout-set-fullscreen))
-        (spacemacs/toggle-maximize-buffer)))
-
-    ;; Quick swtiching between workspaces
-    (defvar exwm-toggle-workspace 0
-      "Previously selected workspace. Used with `exwm-jump-to-last-exwm'.")
-    (defun exwm-jump-to-last-exwm ()
-      (interactive)
-      (exwm-workspace-switch exwm-toggle-workspace))
-    (defadvice exwm-workspace-switch (before save-toggle-workspace activate)
-      (setq exwm-toggle-workspace exwm-workspace-current-index))
-
-    (defun spacemacs/exwm-app-launcher (command)
-      "Launches an application in your PATH.
-Can show completions at point for COMMAND using helm or ido"
-      (interactive (list (read-shell-command exwm-app-launcher--prompt)))
-      (start-process-shell-command command nil command))
 
     ;; `exwm-input-set-key' allows you to set a global key binding (available in
     ;; any case). Following are a few examples.
     ;; + We always need a way to go back to line-mode from char-mode
     (exwm-input-set-key (kbd "s-r") 'exwm-reset)
 
-    (exwm-input-set-key (kbd "s-f") #'spacemacs/exwm-layout-toggle-fullscreen)
-    (exwm-input-set-key (kbd "<s-tab>") #'exwm-jump-to-last-exwm)
+    (exwm-input-set-key (kbd "s-f") #'exwm/exwm-layout-toggle-fullscreen)
+    (exwm-input-set-key (kbd "<s-tab>") #'exwm/jump-to-last-exwm)
     ;; + Bind a key to switch workspace interactively
     (exwm-input-set-key (kbd "s-w") 'exwm-workspace-switch)
     ;; + Set shortcuts to switch to a certain workspace.
@@ -172,20 +104,14 @@ Can show completions at point for COMMAND using helm or ido"
                         (lambda () (interactive) (exwm-workspace-switch 8)))
     (exwm-input-set-key (kbd "s-0")
                         (lambda () (interactive) (exwm-workspace-switch 9)))
-    ;; + Application launcher ('M-&' also works if the output buffer does not
-    ;;   bother you). Note that there is no need for processes to be created by
-    ;;   Emacs.
-    (exwm-input-set-key (kbd "s-SPC") #'spacemacs/exwm-app-launcher)
-    ;; + 'slock' is a simple X display locker provided by suckless tools. 'i3lock'
-    ;;   is a more feature-rich alternative.
-    (exwm-input-set-key (kbd "<s-escape>")
-                        (lambda () (interactive) (start-process "" nil exwm--locking-command)))
     ;; The following example demonstrates how to set a key binding only available
     ;; in line mode. It's simply done by first push the prefix key to
     ;; `exwm-input-prefix-keys' and then add the key sequence to `exwm-mode-map'.
     ;; The example shorten 'C-c q' to 'C-q'.
     (push ?\C-q exwm-input-prefix-keys)
     (define-key exwm-mode-map [?\C-q] 'exwm-input-send-next-key)
+    (exwm-input-set-key (kbd "s-SPC") #'exwm/exwm-app-launcher)
+    (exwm-input-set-key (kbd "s-l") 'exwm/exwm-lock)
 
     ;; M-m leader, sorry Space Folks
     (push ?\M-m exwm-input-prefix-keys)
@@ -235,8 +161,8 @@ Can show completions at point for COMMAND using helm or ido"
     (exwm-input-set-key (kbd "M-s-k") #'spacemacs/enlarge-window)
     (exwm-input-set-key (kbd "M-s-l") #'spacemacs/enlarge-window-horizontally)
     ;; Workspaces
-    (exwm-input-set-key (kbd "s-]") #'spacemacs/exwm-workspace-next)
-    (exwm-input-set-key (kbd "s-[") #'spacemacs/exwm-workspace-prev)
+    (exwm-input-set-key (kbd "s-]") #'exwm/exwm-workspace-next)
+    (exwm-input-set-key (kbd "s-[") #'exwm/exwm-workspace-prev)
 
     (require 'exwm-randr)
     (setq exwm-randr-workspace-output-plist '(0 "VGA1"))

--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -187,26 +187,21 @@
     ;; Undo window configurations
     (exwm-input-set-key (kbd "s-u") #'winner-undo)
     (exwm-input-set-key (kbd "S-s-U") #'winner-redo)
-    ;; Focusing windows
-    (exwm-input-set-key (kbd "s-h") #'evil-window-left)
-    (exwm-input-set-key (kbd "s-j") #'evil-window-down)
-    (exwm-input-set-key (kbd "s-k") #'evil-window-up)
-    (exwm-input-set-key (kbd "s-l") #'evil-window-right)
-    ;; Moving Windows
-    (exwm-input-set-key (kbd "s-H") #'evil-window-move-far-left)
-    (exwm-input-set-key (kbd "s-J") #'evil-window-move-very-bottom)
-    (exwm-input-set-key (kbd "s-K") #'evil-window-move-very-top)
-    (exwm-input-set-key (kbd "s-L") #'evil-window-move-far-right)
-    ;; Resize
-    (exwm-input-set-key (kbd "M-s-h") #'spacemacs/shrink-window-horizontally)
-    (exwm-input-set-key (kbd "M-s-j") #'spacemacs/shrink-window)
-    (exwm-input-set-key (kbd "M-s-k") #'spacemacs/enlarge-window)
-    (exwm-input-set-key (kbd "M-s-l") #'spacemacs/enlarge-window-horizontally)
     ;; Workspaces
     (exwm-input-set-key (kbd "s-]") #'exwm/exwm-workspace-next)
     (exwm-input-set-key (kbd "s-[") #'exwm/exwm-workspace-prev)
 
     (spacemacs/declare-prefix "W" "EXWM")
+    (spacemacs/set-leader-keys
+      "Wp" 'exwm/exwm-workspace-prev
+      "Wn" 'exwm/exwm-workspace-next
+      "Wf" 'exwm-layout-set-fullscreen
+      "WA" 'exwm-workspace-add
+      "Wd" 'exwm-workspace-delete
+      "WR" 'exwm-restart
+      "Wr" 'exwm-reset
+      "Wl" 'exwm/exwm-lock
+      "Wa" 'exwm/exwm-app-launcher)
     (exwm-randr-enable)
     (exwm-systemtray-enable)
     ;; The following example demonstrates how to use simulation keys to mimic the

--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -14,7 +14,7 @@
 ;; which require an initialization must be listed explicitly in the list.
 (defconst exwm-packages
     '(cl-generic
-      helm-exwm
+      (helm-exwm :requires helm)
       (evil-exwm-state :location (recipe :fetcher github
                                          :repo "domenzain/evil-exwm-state"))
       (xelb :location (recipe :fetcher github
@@ -26,21 +26,19 @@
 
 (defun exwm/init-helm-exwm ()
   ;; when helm is used activate extra EXWM features
-  (spacemacs|use-package-add-hook helm
-    :post-config
-    (use-package helm-exwm
-      :config
-      (progn
-        ;; Add EXWM buffers to a specific section in helm mini
-        (setq exwm/helm-exwm-emacs-buffers-source
-              (helm-exwm-build-emacs-buffers-source))
-        (setq exwm/helm-exwm-source (helm-exwm-build-source))
-        (setq helm-mini-default-sources `(exwm/helm-exwm-emacs-buffers-source
-                                          exwm/helm-exwm-source
-                                          helm-source-recentf
-                                          helm-source-buffer-not-found))
-        ;; Add a prefix command to choose among EXWM buffers only
-        (spacemacs/set-leader-keys "WW" 'helm-exwm)))))
+  (use-package helm-exwm
+    :config
+    (progn
+      ;; Add EXWM buffers to a specific section in helm mini
+      (setq exwm-helm-exwm-emacs-buffers-source
+            (helm-exwm-build-emacs-buffers-source))
+      (setq exwm-helm-exwm-source (helm-exwm-build-source))
+      (setq helm-mini-default-sources `(exwm-helm-exwm-emacs-buffers-source
+                                        exwm-helm-exwm-source
+                                        helm-source-recentf
+                                        helm-source-buffer-not-found))
+      ;; Add a prefix command to choose among EXWM buffers only
+      (spacemacs/set-leader-keys "WW" 'helm-exwm))))
 
 (defun exwm/init-evil-exwm-state ()
   (use-package evil-exwm-state

--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -118,6 +118,10 @@
 
     ;; `exwm-input-set-key' allows you to set a global key binding (available in
     ;; any case). Following are a few examples.
+
+    (exwm-input-set-key (kbd "s-i") 'exwm-input-toggle-keyboard)
+    (exwm-input-set-key (kbd "M-m") 'spacemacs-cmds)
+    (exwm-input-set-key (kbd "C-q") 'exwm-input-send-next-key)
     ;; + We always need a way to go back to line-mode from char-mode
     (exwm-input-set-key (kbd "s-r") 'exwm-reset)
 
@@ -125,65 +129,12 @@
     (exwm-input-set-key (kbd "<s-tab>") #'exwm/jump-to-last-exwm)
     ;; + Bind a key to switch workspace interactively
     (exwm-input-set-key (kbd "s-w") 'exwm-workspace-switch)
-    ;; + Set shortcuts to switch to a certain workspace.
-    (exwm-input-set-key (kbd "s-1")
-                        (lambda () (interactive) (exwm-workspace-switch 0)))
-    (exwm-input-set-key (kbd "s-2")
-                        (lambda () (interactive) (exwm-workspace-switch 1)))
-    (exwm-input-set-key (kbd "s-3")
-                        (lambda () (interactive) (exwm-workspace-switch 2)))
-    (exwm-input-set-key (kbd "s-4")
-                        (lambda () (interactive) (exwm-workspace-switch 3)))
-    (exwm-input-set-key (kbd "s-5")
-                        (lambda () (interactive) (exwm-workspace-switch 4)))
-    (exwm-input-set-key (kbd "s-6")
-                        (lambda () (interactive) (exwm-workspace-switch 5)))
-    (exwm-input-set-key (kbd "s-7")
-                        (lambda () (interactive) (exwm-workspace-switch 6)))
-    (exwm-input-set-key (kbd "s-8")
-                        (lambda () (interactive) (exwm-workspace-switch 7)))
-    (exwm-input-set-key (kbd "s-9")
-                        (lambda () (interactive) (exwm-workspace-switch 8)))
-    (exwm-input-set-key (kbd "s-0")
-                        (lambda () (interactive) (exwm-workspace-switch 9)))
-    ;; The following example demonstrates how to set a key binding only available
-    ;; in line mode. It's simply done by first push the prefix key to
-    ;; `exwm-input-prefix-keys' and then add the key sequence to `exwm-mode-map'.
-    ;; The example shorten 'C-c q' to 'C-q'.
-    (push ?\C-q exwm-input-prefix-keys)
-    (define-key exwm-mode-map [?\C-q] 'exwm-input-send-next-key)
     (exwm-input-set-key (kbd "s-SPC") #'exwm/exwm-app-launcher)
     (exwm-input-set-key (kbd "s-l") 'exwm/exwm-lock)
 
-    ;; M-m leader, sorry Space Folks
-    (push ?\M-m exwm-input-prefix-keys)
-    ;; Universal Get-me-outta-here
-    (push ?\C-g exwm-input-prefix-keys)
-    ;; Universal Arguments
-    (push ?\C-u exwm-input-prefix-keys)
-    (push ?\C-0 exwm-input-prefix-keys)
-    (push ?\C-1 exwm-input-prefix-keys)
-    (push ?\C-2 exwm-input-prefix-keys)
-    (push ?\C-3 exwm-input-prefix-keys)
-    (push ?\C-4 exwm-input-prefix-keys)
-    (push ?\C-5 exwm-input-prefix-keys)
-    (push ?\C-6 exwm-input-prefix-keys)
-    (push ?\C-7 exwm-input-prefix-keys)
-    (push ?\C-8 exwm-input-prefix-keys)
-    (push ?\C-9 exwm-input-prefix-keys)
-    ;; C-c, C-x are needed for copying and pasting
-    (delete ?\C-x exwm-input-prefix-keys)
-    (delete ?\C-c exwm-input-prefix-keys)
-    ;; We can use `M-m h' to access help
-    (delete ?\C-h exwm-input-prefix-keys)
     ;; set up evil escape
     (exwm-input-set-key [escape] 'evil-escape)
 
-    ;; Preserve the habit
-    (exwm-input-set-key (kbd "s-:") 'helm-M-x)
-    (exwm-input-set-key (kbd "s-;") 'evil-ex)
-    ;; Shell (not a real one for the moment)
-    (exwm-input-set-key (kbd "C-'") #'spacemacs/default-pop-shell)
     ;; Undo window configurations
     (exwm-input-set-key (kbd "s-u") #'winner-undo)
     (exwm-input-set-key (kbd "S-s-U") #'winner-redo)

--- a/layers/+window-management/exwm/packages.el
+++ b/layers/+window-management/exwm/packages.el
@@ -65,23 +65,23 @@
     (setq use-dialog-box nil)
     ;; Use as many workspaces as there are connected displays
     ;; TODO: Is there a way of doing this with xelb?
-    (defvar exwm//randr-displays (split-string
+    (defvar exwm--randr-displays (split-string
                             (shell-command-to-string
                              "xrandr | grep ' connected' | cut -d' ' -f1 "))
       "The list of connected RandR displays")
     ;; Set at least as many workspaces as there are connected displays.
     ;; At the user's option, begin with even more workspaces
     (setq exwm-workspace-number
-          (if exwm/workspace-number
-              (max exwm/workspace-number (list-length exwm//randr-displays))
-              (list-length exwm//randr-displays)))
+          (if exwm-workspace-number
+              (max exwm-workspace-number (list-length exwm--randr-displays))
+              (list-length exwm--randr-displays)))
     ;; The first workspaces will match the order in RandR
     (setq exwm-randr-workspace-output-plist
-          (exwm//flatenum 0 exwm//randr-displays))
+          (exwm//flatenum 0 exwm--randr-displays))
 
     ;; You may want Emacs to show you the time
     (display-time-mode t)
-    (when exwm/hide-tiling-modeline
+    (when exwm-hide-tiling-modeline
       (add-hook 'exwm-mode-hook #'hidden-mode-line-mode))
 
     :config
@@ -105,7 +105,7 @@
                             (string= "gimp" exwm-instance-name))
                     (exwm-workspace-rename-buffer exwm-title)))))
 
-    (exwm/exwm-bind-command "s-'"  exwm/terminal-command)
+    (exwm/exwm-bind-command "s-'"  exwm-terminal-command)
     (exwm/exwm-bind-command "<XF86MonBrightnessUp>"
                                  "light -A 5")
     (exwm/exwm-bind-command "<XF86MonBrightnessDown>"
@@ -163,9 +163,9 @@
     (exwm-randr-enable)
     (exwm-systemtray-enable)
 
-    (if exwm/xrandr-command
+    (if exwm-randr-command
      (start-process-shell-command
-      "xrandr" nil exwm/xrandr-command))
+      "xrandr" nil exwm-randr-command))
     ;; The following example demonstrates how to use simulation keys to mimic the
     ;; behavior of Emacs. The argument to `exwm-input-set-simulation-keys' is a
     ;; list of cons cells (SRC . DEST), where SRC is the key sequence you press and


### PR DESCRIPTION
Hi @CestDiego ,

I've taken your EXWM layer pull request for Spacemacs, rebased it onto the latest `develop` branch commit and extended it a bit to :

- Use helm where possible
- Use evil states that match EXWM input modes
- Integrate into powerline theme
- Match the layer conventions in Spacemacs for naming and code organization

Some things require a bit of work, like deciding on prefix commands and keymaps. And things like my xrandr configuration should probably be put somewhere else.
I have also temporarily removed your original keybindings as I'm trying to privilege use of a leader key.

Are you still interested in updating that original pull request?

Best,